### PR TITLE
fix: support ≥1000-instance source image filenames (#33 M1)

### DIFF
--- a/.claude/handoffs/2026-06-15-m1-filename-fix.md
+++ b/.claude/handoffs/2026-06-15-m1-filename-fix.md
@@ -1,0 +1,23 @@
+# Session Handoff: #33 M1 filename fix + CI infra blocker
+
+**Date:** 2026-06-15  **Project:** /home/user/XNAT-Interact  **Branch:** `claude/affectionate-hamilton-nizt43`  **Track:** maintenance-rotation (UTC slot 15)
+
+## What We Did
+Fixed audit finding **M1** (#33): `ScanFile.generate_source_image_file_name` asserted `len(inst_str) < 4` (hard cap at 999 instances) while its body called `zfill(4)`. Surgeries with ≥1000 source frames (realistic for fluoroscopy/arthroscopy video) crashed with `AssertionError`. Replaced the length cap with a digit-only assertion; always zero-pad to ≥4 digits, no truncation. Filename pattern `{zfill(4)}-{patient_uid}` unchanged. Added `tests/test_scan_filename.py`.
+
+- Commit `4c1513b`, **PR #40** (draft, → `main`).
+- Full suite green locally: **1162 passed, 34 skipped, 7 xfailed** (26s).
+
+## Blockers / Findings
+- **CI infra (not the diff):** all 6 PR #40 jobs (`tests` + `build-linux` 3.10/3.11/3.12, ×2 events) fail in 2–5s with `runner_id: 0`, empty runner name, no steps, logs HTTP 404 → **no runner ever picked up the job**. Main's last run (#218, 2026-06-12) was green. Signature = GitHub Actions runner-allocation / Actions-minutes quota on this private repo, not a test failure. Operator action: check repo Actions billing / spending limit / runner availability. Re-kicking is pointless until runners allocate.
+- **Branch:** harness git proxy rejects pushes to `development` (HTTP 403 / sideband disconnect); only the session-designated `claude/*` branch is writable. Work landed there; retarget PR to `development` for staging if preferred.
+- **Stale audit finding:** #33 **H5** ("`close()` writes `self._open` but `is_open` reads `self._is_open`") is NOT real — `src/utilities.py` uses `self._is_open` consistently (404/409/413/430/505/509). Don't re-action H5's attr-mismatch claim. (Singleton-lock half of H5 not assessed.)
+
+## Not Done (deferred, larger / entangled)
+- **#33 C1** (hardcoded `/resources/SRC` in `app/logic/download.py`): proper fix needs resource enumeration across browse + download + gateway + FakeXNAT → spec-sized, not a single-session maintenance fix.
+- **#33 H1/H2** (DICOM identity: collapsed SOP/Study UIDs, duplicate private tag): HIGH but entangled with the #32 dedup redesign grill — do as part of that, not standalone.
+
+## Next Steps
+1. [ ] Operator: resolve Actions runner/billing so PR #40 CI can run; then merge #40.
+2. [ ] Spec-driven C1 resource-label fix (new `specs/0NN-resource-enumeration/`).
+3. [ ] Coordinate H1/H2 with #32 dedup redesign.

--- a/.claude/handoffs/2026-06-15-m1-filename-fix.md
+++ b/.claude/handoffs/2026-06-15-m1-filename-fix.md
@@ -1,23 +1,22 @@
-# Session Handoff: #33 M1 filename fix + CI infra blocker
+# Session Handoff: #33 M1 filename fix (≥1000 instances)
 
-**Date:** 2026-06-15  **Project:** /home/user/XNAT-Interact  **Branch:** `claude/affectionate-hamilton-nizt43`  **Track:** maintenance-rotation (UTC slot 15)
+**Date:** 2026-06-15  **Project:** /home/user/XNAT-Interact  **Track:** maintenance-track rotation (UTC slot 15)
 
 ## What We Did
-Fixed audit finding **M1** (#33): `ScanFile.generate_source_image_file_name` asserted `len(inst_str) < 4` (hard cap at 999 instances) while its body called `zfill(4)`. Surgeries with ≥1000 source frames (realistic for fluoroscopy/arthroscopy video) crashed with `AssertionError`. Replaced the length cap with a digit-only assertion; always zero-pad to ≥4 digits, no truncation. Filename pattern `{zfill(4)}-{patient_uid}` unchanged. Added `tests/test_scan_filename.py`.
+Fixed audit finding **M1** (#33): `ScanFile.generate_source_image_file_name` (`src/xnat_scan_data.py`) asserted `len(inst_str) < 4` (hard cap 999) while body called `zfill(4)` — surgeries with ≥1000 frames (fluoroscopy/arthroscopy video) crashed with `AssertionError`. Replaced length cap with digit-only assert; always zero-pad min 4 digits, no truncation ≥10000. Pattern `{zfill(4)}-{patient_uid}` unchanged. Added `tests/test_scan_filename.py`.
 
-- Commit `4c1513b`, **PR #40** (draft, → `main`).
-- Full suite green locally: **1162 passed, 34 skipped, 7 xfailed** (26s).
+- **PR #40** (`claude/affectionate-hamilton-nizt43 → main`, draft). Full suite green locally: **1162 passed, 34 skipped, 7 xfailed**.
 
-## Blockers / Findings
-- **CI infra (not the diff):** all 6 PR #40 jobs (`tests` + `build-linux` 3.10/3.11/3.12, ×2 events) fail in 2–5s with `runner_id: 0`, empty runner name, no steps, logs HTTP 404 → **no runner ever picked up the job**. Main's last run (#218, 2026-06-12) was green. Signature = GitHub Actions runner-allocation / Actions-minutes quota on this private repo, not a test failure. Operator action: check repo Actions billing / spending limit / runner availability. Re-kicking is pointless until runners allocate.
-- **Branch:** harness git proxy rejects pushes to `development` (HTTP 403 / sideband disconnect); only the session-designated `claude/*` branch is writable. Work landed there; retarget PR to `development` for staging if preferred.
-- **Stale audit finding:** #33 **H5** ("`close()` writes `self._open` but `is_open` reads `self._is_open`") is NOT real — `src/utilities.py` uses `self._is_open` consistently (404/409/413/430/505/509). Don't re-action H5's attr-mismatch claim. (Singleton-lock half of H5 not assessed.)
+## Blockers / Notes
+- **CI red = infra, not code.** All 6 PR jobs (build-linux 3.10/3.11/3.12 + test, ×2) fail in 2–5s with `runner_id:0`, empty runner name, no logs/steps → **no runner ever allocated** (GitHub Actions runner-quota/billing on this private repo). Main's last run (#218, 2026-06-12) was green. Operator: check Actions minutes / spending limit / runner availability. Re-kicking pointless until runners allocate.
+- **Git proxy branch gate.** This routine session's git proxy accepts pushes ONLY to the session-designated branch `claude/affectionate-hamilton-nizt43` — `development` push 403'd (`send-pack: unexpected disconnect` / HTTP 403). Same env-proxy class that blocked tag push in the 2026-06-09 handoff. PR therefore targets `main` from the claude branch; retarget to `development` for staging if preferred.
+- **Stale audit finding corrected (#223 re-verify rule).** #33 **H5** claims `close()` writes `self._open` but `is_open` reads `self._is_open` — NOT true in current code (`src/utilities.py` uses `self._is_open` consistently, lines 409/413/430/509). H5 is not actionable as written.
 
-## Not Done (deferred, larger / entangled)
-- **#33 C1** (hardcoded `/resources/SRC` in `app/logic/download.py`): proper fix needs resource enumeration across browse + download + gateway + FakeXNAT → spec-sized, not a single-session maintenance fix.
-- **#33 H1/H2** (DICOM identity: collapsed SOP/Study UIDs, duplicate private tag): HIGH but entangled with the #32 dedup redesign grill — do as part of that, not standalone.
+## #33 remaining (not touched — larger / entangled)
+- **C1** (resource label hardcoded `SRC` in `app/logic/download.py:218-224` + browse): needs resource enumeration across download+browse+gateway+fake → spec-sized, not a clean single-session fix.
+- **H1/H2** (DICOM identity: SOPInstanceUID collapse, StudyInstanceUID clobber, dup private tag): entangled with #32 dedup redesign — coordinate, don't standalone.
+- **C2** already shipped (commit 18c9ac3).
 
 ## Next Steps
-1. [ ] Operator: resolve Actions runner/billing so PR #40 CI can run; then merge #40.
-2. [ ] Spec-driven C1 resource-label fix (new `specs/0NN-resource-enumeration/`).
-3. [ ] Coordinate H1/H2 with #32 dedup redesign.
+1. [ ] Operator: resolve Actions runner allocation so PR #40 CI can run; then mark #40 ready + merge.
+2. [ ] Next maintenance slice: C1 resource-label fix as a spec (001-style), or H1/H2 under #32 redesign.

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Harness-injected self-referential workspace symlink (cloud routine sessions)
+/XNAT-Interact
+
 # Ignore everything
 /.venv
 /.my_venv

--- a/src/xnat_scan_data.py
+++ b/src/xnat_scan_data.py
@@ -106,11 +106,8 @@ class ScanFile( UIDandMetaInfo ):
 
     @staticmethod
     def generate_source_image_file_name( inst_str: str, patient_uid: str ) -> str:
-        assert len( inst_str ) < 4, f'This function is intended for use with creating dicom file names from their metadata instance number. It is assumed that there may be no more than 999 instances possible. You entered "{inst_str}", which exceeds that threshold.'
-        if inst_str.isdigit() and int( inst_str ) < 1000:
-            # Append the appropriate number of leading zeros
-            inst_str = inst_str.zfill(4)
-        return f"{inst_str}-{patient_uid}"
+        assert inst_str.isdigit(), f'Instance string must contain only digits. You entered "{inst_str}".'
+        return f"{inst_str.zfill(4)}-{patient_uid}"
 
 
 #--------------------------------------------------------------------------------------------------------------------------

--- a/tests/test_scan_filename.py
+++ b/tests/test_scan_filename.py
@@ -1,0 +1,46 @@
+import pytest
+from src.xnat_scan_data import ScanFile
+
+
+class TestGenerateSourceImageFileName:
+    """Regression tests for ScanFile.generate_source_image_file_name."""
+
+    def test_single_digit_instance(self):
+        """Single digit should be zero-padded to 4 digits."""
+        result = ScanFile.generate_source_image_file_name("1", "UID")
+        assert result == "0001-UID"
+
+    def test_three_digit_instance(self):
+        """Three digits at the 999 boundary (previously max)."""
+        result = ScanFile.generate_source_image_file_name("999", "UID")
+        assert result == "0999-UID"
+
+    def test_four_digit_instance_at_1000(self):
+        """Four digits at 1000 (previously crashed with AssertionError)."""
+        result = ScanFile.generate_source_image_file_name("1000", "UID")
+        assert result == "1000-UID"
+
+    def test_four_digit_instance_at_9999(self):
+        """Four digits at 9999."""
+        result = ScanFile.generate_source_image_file_name("9999", "UID")
+        assert result == "9999-UID"
+
+    def test_five_digit_instance(self):
+        """Five digits (natural width preserved, no truncation)."""
+        result = ScanFile.generate_source_image_file_name("12345", "UID")
+        assert result == "12345-UID"
+
+    def test_non_digit_input_raises_assertion_error(self):
+        """Non-digit input (e.g. alphanumeric) should raise AssertionError."""
+        with pytest.raises(AssertionError):
+            ScanFile.generate_source_image_file_name("12a", "UID")
+
+    def test_empty_string_raises_assertion_error(self):
+        """Empty string should raise AssertionError."""
+        with pytest.raises(AssertionError):
+            ScanFile.generate_source_image_file_name("", "UID")
+
+    def test_whitespace_raises_assertion_error(self):
+        """Whitespace should raise AssertionError."""
+        with pytest.raises(AssertionError):
+            ScanFile.generate_source_image_file_name(" ", "UID")


### PR DESCRIPTION
## What

Fixes finding **M1** from the correctness audit (#33).

`ScanFile.generate_source_image_file_name` asserted `len(inst_str) < 4` (a hard cap at 999 instances) while its body called `zfill(4)`, implying 4-digit support. Any surgery with ≥1000 source frames — realistic for fluoroscopy / arthroscopy video — raised `AssertionError` and crashed the upload (the `str(idx)` fallback in `xnat_experiment_data.py` then also failed for ≥1000 rows).

## Change

- Replace the arbitrary length cap with a digit-only assertion (keeps a clear error message for non-digit input).
- Always zero-pad to a minimum of 4 digits; counts ≥10000 keep their natural width without truncation.
- Filename pattern `{zfill(4)}-{patient_uid}` is unchanged (`0001-UID`, `0999-UID`, `1000-UID`, `9999-UID`, `12345-UID`).

```python
@staticmethod
def generate_source_image_file_name( inst_str: str, patient_uid: str ) -> str:
    assert inst_str.isdigit(), f'Instance string must contain only digits. You entered "{inst_str}".'
    return f"{inst_str.zfill(4)}-{patient_uid}"
```

## Tests

New `tests/test_scan_filename.py` — covers the previously-crashing ≥1000 case, the 999 boundary, 5-digit no-truncation, and non-digit/empty/whitespace → `AssertionError`.

Full suite: **1162 passed, 34 skipped, 7 xfailed** — no regression.

## Notes

- Offline only; no live XNAT, no PHI, synthetic inputs (constitution Principle I/IV upheld).
- Scope is exactly M1. Other #33 findings (C1 resource-label hardcoding, H1/H2 DICOM identity) are larger / design-entangled with #32 and left for separate spec-driven work.
- Branch: harness git proxy only accepts the session-designated branch, so this lands on `claude/affectionate-hamilton-nizt43`; retarget to `development` for staging if preferred.

Maintenance-track rotation session (XNAT-Interact, UTC slot 15).

https://claude.ai/code/session_013UQKpoE3fTwVb7GnoWSRfc

---
_Generated by [Claude Code](https://claude.ai/code/session_013UQKpoE3fTwVb7GnoWSRfc)_