### PR TITLE
fix: reset DataFrame index after NEW_FN sort in _mine_session_metadata (#33 M3)

### DIFF
--- a/src/xnat_experiment_data.py
+++ b/src/xnat_experiment_data.py
@@ -778,7 +778,12 @@ class SourceRFSession( ExperimentData ):
             self._df.at[idx, 'NEW_FN'] = dicom_obj.generate_source_image_file_name( _inst_str, self.intake_form.uid )
 
         # self._derive_acquisition_site_info() # to-do: should warn the user that any mined info is inconsistent with their input
-        self._df = self.df.sort_values( by='NEW_FN', inplace=False )
+        # #33 M3: reset to a contiguous RangeIndex after sorting.  The downstream
+        # write() loop iterates `for idx in range(len(self.df))` and indexes with
+        # label-based `.loc[idx]`; without this reset a sorted (or row-filtered)
+        # index is a non-contiguous permutation, so .loc[idx] either reads the
+        # wrong row or raises KeyError on a gapped index.
+        self._df = self.df.sort_values( by='NEW_FN', inplace=False ).reset_index( drop=True )
 
     # ---------------------------------_populate_df Helper Methods---------------------------------
     def _all_dicom_ffns( self ) -> list:

--- a/tests/test_session_df_index_m3.py
+++ b/tests/test_session_df_index_m3.py
@@ -1,0 +1,120 @@
+"""
+tests/test_session_df_index_m3.py -- #33 M3 regression.
+
+_mine_session_metadata ended with `sort_values(by='NEW_FN')` but never
+reset the index.  The downstream write() loop uses `for idx in range(len(df))`
+with label-based `.loc[idx]`, so a sorted/gapped (non-contiguous) index made
+.loc[idx] read the wrong row or raise KeyError.  This guards the reset_index fix:
+after mining, the dataframe index must be a contiguous RangeIndex 0..n-1.
+
+Offline only. No real server, no real PHI. No pyxnat.
+"""
+from __future__ import annotations
+
+import types
+
+import pandas as pd
+import pytest
+from types import SimpleNamespace
+from typing import Any
+
+import src.xnat_experiment_data as _mod
+
+
+class _FakeMetadata:
+    """Mimics a pydicom FileDataset metadata holder; rejects duplicate tags."""
+
+    def __init__(self) -> None:
+        self._private_tags: dict[tuple, tuple[str, Any]] = {}
+
+    def add_new(self, tag: tuple, vr: str, value: Any) -> None:
+        if tag in self._private_tags:
+            raise ValueError(f"Tag {tag} already exists")
+        self._private_tags[tag] = (vr, value)
+
+
+def _make_dicom_obj(sop_tail: str, fn_key: str) -> SimpleNamespace:
+    """Minimal SourceDicomDeIdentified stand-in with all stashable metadata."""
+    obj = SimpleNamespace(
+        metadata=_FakeMetadata(),
+        StudyDate="20240101",
+        StudyTime="120000",
+        StudyInstanceUID="1.2.3.4." + sop_tail,
+        SeriesInstanceUID="1.2.3.4.5." + sop_tail,
+        SOPInstanceUID="1.2.3.4.5.6." + sop_tail,
+        NumberOfStudyRelatedInstances=3,
+        ContentTime="120000",
+        _derived_metadata={"DATETIME": "2024-01-01 12:00:00"},
+        image=SimpleNamespace(hash_str="aabbcc" + sop_tail),
+    )
+    # NEW_FN is fn_key-derived so the post-sort order is deterministic and
+    # (by construction below) the reverse of row order — proves the sort runs.
+    obj.generate_source_image_file_name = lambda inst_str, uid, k=fn_key: f"{k}-{uid}"
+    return obj
+
+
+class _MinimalRFSession:
+    """Drives the real _mine_session_metadata with no file I/O."""
+
+    def __init__(self, df: pd.DataFrame, uid: str = "9.9.9") -> None:
+        self._df = df
+        self.intake_form = SimpleNamespace(
+            uid=uid, operation_date="20240101", epic_start_time="120000",
+        )
+
+    @property
+    def df(self) -> pd.DataFrame:
+        return self._df
+
+    def run(self) -> None:
+        types.MethodType(_mod.SourceRFSession._mine_session_metadata, self)()
+
+
+def _build_df(index: list[int]) -> pd.DataFrame:
+    n = len(index)
+    rows = []
+    for i in range(n):
+        # Descending zero-padded keys: row 0 gets the largest, so NEW_FN sort
+        # reverses row order -- a non-trivial permutation that exercises the sort.
+        fn_key = f"{n - i:04d}"
+        rows.append({
+            "FN": f"frame_{i}.dcm", "EXT": ".dcm", "NEW_FN": "",
+            "OBJECT": _make_dicom_obj(str(i), fn_key),
+            "IS_VALID": True, "IS_QUESTIONABLE": False,
+            "DATE": None, "SERIES_TIME": None, "INSTANCE_TIME": None,
+            "INSTANCE_NUM": None, "ContentTime": None, "InstanceNumber": None,
+        })
+    return pd.DataFrame(rows, index=index)
+
+
+def test_contiguous_index_after_mining_clean_input():
+    session = _MinimalRFSession(_build_df([0, 1, 2]))
+    session.run()
+    assert list(session.df.index) == [0, 1, 2]
+
+
+def test_contiguous_index_after_mining_gapped_input():
+    # Gapped index simulates rows dropped before mining; pre-fix this leaves a
+    # non-contiguous index so the write() range(len)+.loc[idx] loop KeyErrors.
+    session = _MinimalRFSession(_build_df([0, 2, 5]))
+    session.run()
+    assert list(session.df.index) == [0, 1, 2]
+
+
+def test_write_loop_access_pattern_is_safe():
+    # Reproduce the write() access pattern (range(len) + label .loc) post-mining.
+    session = _MinimalRFSession(_build_df([3, 7, 11]))
+    session.run()
+    for idx in range(len(session.df)):
+        # Must not raise KeyError.
+        assert session.df.loc[idx, "NEW_FN"] is not None
+
+
+def test_rows_in_sorted_newfn_order_after_mining():
+    # NEW_FN keys are descending by row, so after sort they ascend and the
+    # contiguous index must line up with sorted NEW_FN values.
+    session = _MinimalRFSession(_build_df([0, 2, 5]))
+    session.run()
+    new_fns = list(session.df["NEW_FN"])
+    assert new_fns == sorted(new_fns)
+    assert list(session.df.index) == [0, 1, 2]


### PR DESCRIPTION
## What

Fixes finding **M3** from the correctness audit (#33).

`SourceRFSession._mine_session_metadata` ends with `sort_values(by='NEW_FN', inplace=False)` but never resets the index. The downstream `write()` loop iterates `for idx in range(len(self.df))` and indexes label-based via `.loc[idx]`. After the sort the index is a non-contiguous permutation of the original labels, so:

- on a clean `0..n-1` index the sort is silently a **no-op** for write order (`.loc[idx]` reads by label, not sorted position);
- on a **gapped** index (e.g. invalid rows dropped before mining) `.loc[idx]` for `idx` in `range(len)` references a label that no longer exists → **`KeyError`**, or reads the wrong row.

## Change

One line — append `.reset_index(drop=True)` to the sort so the index is a contiguous `RangeIndex` matching the positional write loop:

```python
self._df = self.df.sort_values( by='NEW_FN', inplace=False ).reset_index( drop=True )
```

## Tests

New `tests/test_session_df_index_m3.py` drives the **real** `_mine_session_metadata` (no file I/O, synthetic stand-ins): clean index, gapped index `[0,2,5]`, the `range(len)`+`.loc[idx]` write-loop access pattern, and post-sort ordering. All four **fail without the fix** and pass with it.

Core offline suite: **1123 passed, 7 xfailed**, no new failures (2 unrelated `test_010_verdict` pixel-deid failures are pre-existing — missing spaCy model in this env; verified they fail identically without this change).

## Notes

- Offline only; no live XNAT, no PHI, synthetic inputs (constitution Principle I/IV upheld).
- Single-purpose, scope = M3 exactly. M1 is already covered by #40 — not duplicated here. DICOM-identity findings (H1/H2/M2) are already fixed in current code; the larger C1/concurrency items remain for separate spec-driven work.
- Branch: the session git proxy only accepts the session-designated branch, so this lands on `claude/compassionate-pasteur-x96etr` rather than a direct `development` push; base is `development` per `branching.md` feature flow. Retarget if a different base is preferred.

Maintenance-track rotation session (XNAT-Interact, UTC slot 23).

https://claude.ai/code/session_01LB6TXczf3no6XikRTC3go5

---
_Generated by [Claude Code](https://claude.ai/code/session_01LB6TXczf3no6XikRTC3go5)_