### PR TITLE
fix: guard PyxnatGateway.disconnect() against unconnected server (#33 L4)

### DIFF
--- a/src/services/xnat_gateway.py
+++ b/src/services/xnat_gateway.py
@@ -326,7 +326,10 @@ class PyxnatGateway(XnatGateway):
         self.server = pyxnat.Interface(server=self._url, user=self._user, password=self._password)
 
     def disconnect(self) -> None:
+        if self.server is None:
+            return
         self.server.disconnect()
+        self.server = None
 
     def liveness(self) -> None:
         self.server.get('/')

--- a/tests/test_xnat_gateway.py
+++ b/tests/test_xnat_gateway.py
@@ -362,3 +362,15 @@ class TestCreateAssessorH6Guards:
             self.fake.create_assessor(self.exp_qs, label)
         creates = [c for c in self.fake.calls if c["op"] == "assessor.create"]
         assert len(creates) == len(valid_labels)
+
+
+# ---------------------------------------------------------------------------
+# (d) disconnect() is a safe no-op on an unconnected gateway (#33 L4)
+# ---------------------------------------------------------------------------
+
+def test_disconnect_before_connect_is_noop():
+    """PyxnatGateway.disconnect() must not raise when connect() never ran (#33 L4)."""
+    gw = PyxnatGateway(url="http://example.invalid", user="u", password="p")
+    assert gw.server is None
+    gw.disconnect()  # must NOT raise AttributeError
+    assert gw.server is None


### PR DESCRIPTION
## What

Fixes finding **L4** from the correctness audit (#33).

`PyxnatGateway.disconnect()` dereferenced `self.server`, which is `None` until `connect()` succeeds. Calling `disconnect()` before `connect()` — or after `connect()` raised partway through `pyxnat.Interface(...)` — threw `AttributeError: 'NoneType' object has no attribute 'disconnect'` on a foreseeable path. Per the repo constitution Principle II ("fail softly — no raw traceback for foreseeable problems"), tear-down on an unconnected gateway must be a safe no-op.

## Change

```python
def disconnect(self) -> None:
    if self.server is None:
        return
    self.server.disconnect()
    self.server = None
```

Single-purpose: only `disconnect()` touched. `connect()` / `liveness()` unchanged. Also clears `self.server` after a real disconnect so a double-disconnect is idempotent.

## Tests

New `test_disconnect_before_connect_is_noop` in `tests/test_xnat_gateway.py` constructs a `PyxnatGateway` without connecting and asserts `disconnect()` does not raise. The constructor imports no pyxnat (lazy import inside `connect()`), so the test runs fully offline with no pyxnat installed and no network.

`pytest tests/test_xnat_gateway.py -q` → **27 passed**.

## Notes

- Offline only; no live XNAT, no PHI, synthetic/no inputs (constitution Principles I/IV upheld).
- Scope is exactly L4. Other #33 findings: M1 covered by #40/#38, M3 by #41, M5/M9 by #38, C2 already landed (`18c9ac3`); larger C1/H-class concurrency items remain for separate spec-driven work.
- Base `development` per `branching.md`; head is the session-designated branch (harness git proxy only accepts it).

Maintenance-track rotation session (XNAT-Interact, UTC slot 23 / hour 07).

https://claude.ai/code/session_01SwzZh2D1GfnjEGfgycKuu1

---
_Generated by [Claude Code](https://claude.ai/code/session_01SwzZh2D1GfnjEGfgycKuu1)_