### PR TITLE
fix: install libGL + align python-package.yml CI with tests.yml (#44)

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -16,20 +16,27 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
+    - name: Install system libraries for OpenCV
+      # Several modules `import cv2` at collection time; without libGL the
+      # import fails and pytest exits non-zero. Mirrors tests.yml. (#44)
+      run: sudo apt-get update && sudo apt-get install -y libgl1 libglib2.0-0
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -r requirements.txt
+        pip install -r requirements.txt -r requirements-dev.txt
         pip install flake8 pytest
+        # `pathlib` (a PyPI backport) is listed in requirements.txt but is a
+        # footgun on modern Python; remove it so it can't shadow the stdlib.
+        pip uninstall -y pathlib || true
     - name: Lint with flake8
       run: |
         # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        flake8 . --count --select=E9,F63,F7,F82 --exclude=.git,__pycache__,*.ipynb --show-source --statistics
         # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --exclude=.git,__pycache__,*.ipynb --statistics
     - name: Test with pytest
       run: |
-        # exit code 5 = "no tests collected" — the repo's functional test
-        # (update_and_test.py) needs a live XNAT server, so there is no
-        # pytest suite yet. Treat no-tests as pass; any real failure still fails.
+        # exit code 5 = "no tests collected" — kept as a harmless safety net.
+        # The repo now ships an offline pytest suite under tests/; a real
+        # failure still fails the job.
         pytest || ([ $? -eq 5 ] && echo "No tests collected — treating as pass")


### PR DESCRIPTION
## What

Aligns `.github/workflows/python-package.yml` with the more-complete `tests.yml`:

- **Add the `libgl1`/`libglib2.0-0` system-lib step.** Several modules `import cv2` at pytest collection time (`src/xnat_scan_data.py`, `src/utilities.py`, `tests/synthetic_data.py`, …). Without `libGL.so.1` that import fails and the job exits non-zero. `tests.yml` already installs these; `python-package.yml` did not.
- **Install `requirements-dev.txt`** (pytest/coverage) and **uninstall the `pathlib` PyPI backport** so it can't shadow the stdlib on 3.10–3.12.
- **Exclude `*.ipynb`** from both flake8 invocations (matches `tests.yml`).
- Refresh the stale "no pytest suite yet" comment — the repo now ships ~1154 offline tests under `tests/`.

## Why this is a latent fix, not the current CI-red root cause

Per #44, both workflows are red on every branch. Investigation this session shows the failing jobs **terminate in 2–13 s with zero steps executed** (a full `pip install -r requirements.txt` alone takes minutes locally). They fail at **runner provisioning**, before any workflow step runs — the signature of an **account-level GitHub Actions billing / minutes-exhaustion** issue on this private repo, not a workflow-content bug. That part is **operator-only** (see the diagnosis comment on #44).

This PR fixes a real latent correctness gap so `python-package.yml` is actually green **once Actions can run again**.

## Verification

CI cannot run (billing — see above), so verified locally in a clean Python 3.11 venv mirroring the workflow steps:

- `pip install -r requirements.txt -r requirements-dev.txt` → exit 0 (install is **not** a failure cause).
- `import cv2` → OK (requires libGL, which this PR ensures CI installs).
- `flake8 . --select=E9,F63,F7,F82 --exclude=.git,__pycache__,*.ipynb` → exit 0.
- `pytest` → **1154 passed, 34 skipped, 7 xfailed**, exit 0.

Closes the workflow-alignment portion of #44; the billing root cause stays open for the operator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ovYgvdCMB5jCwryFJJAW4

---
_Generated by [Claude Code](https://claude.ai/code/session_012ovYgvdCMB5jCwryFJJAW4)_