### PR TITLE
fix: preserve original CREATED_BY in ConfigTables metadata (#33 L2)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,7 @@ registry.db
 registry.db-shm
 registry.db-wal
 *.archived-*.json
+
+# Container-created self-referential symlink (repo-root -> /workspace/<repo>);
+# an ephemeral environment artifact, never part of the project tree.
+/XNAT-Interact

--- a/src/utilities.py
+++ b/src/utilities.py
@@ -745,6 +745,7 @@ class ConfigTables( UIDandMetaInfo ):
         self._metadata = {  'CREATED': now_datetime,
                             'LAST_MODIFIED': now_datetime,
                             'CREATED_BY': self.accessor_uid,
+                            'LAST_MODIFIED_BY': self.accessor_uid,
                             'TABLE_EXTRA_COLUMNS': {} }
             
     def _initialize_tables( self ) -> None:
@@ -863,7 +864,8 @@ class ConfigTables( UIDandMetaInfo ):
     
 
     def _update_metadata( self, new_table_extra_columns: Opt[dict] = None ) -> None:
-        self.metadata.update( {'LAST_MODIFIED': self.now_datetime, 'CREATED_BY': self.accessor_uid} )
+        self.metadata.update( {'LAST_MODIFIED': self.now_datetime, 'LAST_MODIFIED_BY': self.accessor_uid} )
+        self.metadata.setdefault( 'CREATED_BY', self.accessor_uid )  # #33 L2: preserve original creator; never overwrite on update
         if new_table_extra_columns is not None:
             for k, v in new_table_extra_columns.items():
                 assert isinstance( v, list ), f'Extra column names for Table "{k}" must be a list of strings.'

--- a/tests/test_metadata_created_by_l2.py
+++ b/tests/test_metadata_created_by_l2.py
@@ -1,0 +1,50 @@
+"""Offline regression test for #33 finding L2.
+
+ConfigTables._update_metadata must preserve the original CREATED_BY and record
+the modifier under LAST_MODIFIED_BY, instead of overwriting CREATED_BY on every
+update. No network, no XNAT server, no PHI — drives the method in isolation.
+"""
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+from unittest import mock
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+if str(REPO_ROOT) not in sys.path:
+    sys.path.insert(0, str(REPO_ROOT))
+
+from src.utilities import ConfigTables
+
+
+def _bare_configtables(metadata: dict) -> ConfigTables:
+    ct = object.__new__(ConfigTables)
+    ct._metadata = metadata
+    return ct
+
+
+def test_l2_update_preserves_original_creator():
+    ct = _bare_configtables(
+        {"CREATED": "t0", "LAST_MODIFIED": "t0", "CREATED_BY": "UID_A",
+         "TABLE_EXTRA_COLUMNS": {}}
+    )
+    with mock.patch.object(ConfigTables, "accessor_uid",
+                           new_callable=mock.PropertyMock, return_value="UID_B"), \
+         mock.patch.object(ConfigTables, "now_datetime",
+                           new_callable=mock.PropertyMock, return_value="t1"):
+        ct._update_metadata()
+    assert ct._metadata["CREATED_BY"] == "UID_A"        # original creator preserved
+    assert ct._metadata["LAST_MODIFIED_BY"] == "UID_B"  # modifier recorded
+    assert ct._metadata["LAST_MODIFIED"] == "t1"
+
+
+def test_l2_update_backfills_created_by_when_absent():
+    ct = _bare_configtables({"CREATED": "t0", "LAST_MODIFIED": "t0",
+                             "TABLE_EXTRA_COLUMNS": {}})
+    with mock.patch.object(ConfigTables, "accessor_uid",
+                           new_callable=mock.PropertyMock, return_value="UID_B"), \
+         mock.patch.object(ConfigTables, "now_datetime",
+                           new_callable=mock.PropertyMock, return_value="t1"):
+        ct._update_metadata()
+    assert ct._metadata["CREATED_BY"] == "UID_B"        # back-compat backfill
+    assert ct._metadata["LAST_MODIFIED_BY"] == "UID_B"


### PR DESCRIPTION
## What

Fixes finding **L2** from the #33 correctness audit.

`ConfigTables._update_metadata` (`src/utilities.py`) overwrote `CREATED_BY` with the current accessor on **every** metadata update:

```python
self.metadata.update( {'LAST_MODIFIED': self.now_datetime, 'CREATED_BY': self.accessor_uid} )
```

So the catalog's "created by" field always reflected the **last modifier**, the original creator's identity was lost, and there was no record of who last modified the catalog.

## Change

- `_update_metadata` now records the modifier under **`LAST_MODIFIED_BY`** and only **backfills** `CREATED_BY` when absent (`setdefault`) — it is never overwritten once set.
- The first-run metadata dict now seeds `LAST_MODIFIED_BY` alongside `CREATED_BY`.

```python
self.metadata.update( {'LAST_MODIFIED': self.now_datetime, 'LAST_MODIFIED_BY': self.accessor_uid} )
self.metadata.setdefault( 'CREATED_BY', self.accessor_uid )  # #33 L2: preserve original creator; never overwrite on update
```

## Tests

New offline `tests/test_metadata_created_by_l2.py` (no server / VPN / PHI) drives `_update_metadata` in isolation via `object.__new__` + `PropertyMock`:
- `test_l2_update_preserves_original_creator` — repeated update by a different accessor keeps the original `CREATED_BY`, records `LAST_MODIFIED_BY`, updates `LAST_MODIFIED`.
- `test_l2_update_backfills_created_by_when_absent` — legacy record lacking `CREATED_BY` gets it backfilled.

Local run (Python 3.11): the new file plus `test_configtables_bootstrap.py`, `test_configtables_registry_writethrough.py`, `test_config.py` → **33 passed, 2 xfailed** (the xfails are pre-existing T007 red-state markers).

## Scope

L2 only. Single-purpose. Maintenance-track rotation slice (XNAT-Interact is not part of the MADMESHing#48 mesh-overhaul roster, which is now closed).

## CI note

This repo's GitHub Actions remains red repo-wide — an account-level Actions billing/startup-failure issue, **not** code (full diagnosis in #44, operator-only). Verified locally instead; checks will show red until billing is restored.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01CwmbzfmzNWMRnJgJeaDMjd

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwmbzfmzNWMRnJgJeaDMjd)_