### PR TITLE
chore: gitignore the environment-provisioned self-referencing symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,3 +39,6 @@ registry.db
 registry.db-shm
 registry.db-wal
 *.archived-*.json
+
+# environment-provisioned self-referencing symlink (container setup, not repo content)
+/XNAT-Interact


### PR DESCRIPTION
## Summary
- Container setup creates a self-referencing symlink `/XNAT-Interact -> /workspace/XNAT-Interact` at repo root; sibling repos (e.g. MADMESHing) already `.gitignore` their equivalent, this repo hadn't.
- One-line `.gitignore` addition; no content/behavior change.

## Context
While investigating why this repo showed zero rotation-session commits for 20+ days (separate finding, reported in chat), a Stop hook flagged this untracked symlink as needing commit. It's environment plumbing, not repo content — fixed the same way sibling repos handle it rather than committing the symlink itself.

## Test plan
- [x] Confirmed `git status` clean after the `.gitignore` change
- [x] No functional code touched

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_012nD8JeUUM88pDTEqeq2sj6)_