### PR TITLE
chore: cut Actions minutes — concurrency cancel + push-on-main-only

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -1,6 +1,16 @@
 name: Python Package
 
-on: [push, pull_request]
+on:
+  # Push only on main (post-merge); feature-branch coverage comes via the PR.
+  # Avoids double-running the 3-python matrix on both push and PR of one commit.
+  push:
+    branches: [main]
+  pull_request:
+
+# Cancel superseded runs when a branch/PR is pushed again.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   build-linux:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,8 +6,15 @@ name: tests
 # and python=3.8 conflicted with the runner's base env.
 
 on:
+  # Push only on main (post-merge); feature-branch coverage comes via the PR.
   push:
+    branches: [main]
   pull_request:
+
+# Cancel superseded runs when a branch/PR is pushed again.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.head_ref || github.ref }}
+  cancel-in-progress: true
 
 jobs:
   test:


### PR DESCRIPTION
## Summary

Part of a cross-repo GitHub Actions minute audit. `tests.yml` and `python-package.yml` both ran on `[push, pull_request]` with no branch filter and no concurrency — so every commit on a PR branch triggered the suite twice (once for push, once for the PR), and `python-package.yml` did so across a 3-version Python matrix.

Changes to both workflows:
- Add `concurrency: cancel-in-progress` (superseded runs cancel).
- Scope `push:` to `[main]` only (post-merge safety); feature-branch coverage still comes via the `pull_request` trigger — this removes the duplicate push-and-PR run on the same commit.

No test logic changed.

## Test Plan
- Edited workflow YAML validated with `yaml.safe_load`.
- Post-merge: a PR commit should trigger each workflow once (PR event), not twice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_019ZQ4xxh5d33HHRtRty4PxG

---
_Generated by [Claude Code](https://claude.ai/code/session_019ZQ4xxh5d33HHRtRty4PxG)_